### PR TITLE
Update install.sh

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -153,6 +153,17 @@ function check_py_packages {
         #echo ""
         missing+=( $i )
         halt=$((halt+1))
+        echo ""
+        echo "missing $i, attempting to install"
+        echo ""
+        pip3 install $i 
+        if pip3 show $i > /dev/null 2>&1
+        then
+          echo ""
+          echo "missing $i installed successfully. continuing..."
+          echo ""
+          halt=$((halt-1))
+        fi
       else
         echo "...OK"
       fi
@@ -161,7 +172,7 @@ function check_py_packages {
 
   if [[ $halt -gt 0 ]]
   then
-    echo "$halt required pytyhon packages are missing. See messages above."
+    echo "$halt required python packages are missing. See messages above."
     echo "install missing packages with:"
     echo "sudo pip3 install ${missing[*]}"
     echo ""


### PR DESCRIPTION
Added a command (and relevant echoes) to attempt to install the missing python packages once automatically before failing the script. Successfully tested on a PiZeroW and Pi4, both running a fresh copy of the latest 32-bit Bullseye Raspbian. Working through other issues with the 64-bit test device at the moment, but I will confirm this change on that one as well. Feel free to change the echo statement. I tried to keep the style close to what is there.

Also fixed typo in output message of missing package