### PR TITLE
abort after pipenv install fails

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -49,7 +49,11 @@ function install_plugin_requirements {
     find $SCRIPT_DIR/../paperpi/plugins -type f -name "requirements-*.txt" -exec cat {} >> $tempfile \; 
     echo "installing Plugin requirements:"
     cat $tempfile
-    pipenv install -r $tempfile --skip-lock
+    if ! command pipenv install -r $tempfile --skip-lock
+    then
+      popd
+      abort "failed to install python modules" 
+    fi
     popd
   else
     echo ""
@@ -81,7 +85,11 @@ function create_pipenv {
   then
     echo "Creating virtual environment for $APPNAME in $INSTALLPATH"
     pushd $INSTALLPATH/$APPNAME
-    pipenv install --skip-lock
+    if ! command pipenv install --skip-lock
+    then
+      popd
+      abort "failed to install python modules"
+    fi
     popd
   else
     echo ""


### PR DESCRIPTION
should abort install if pipenv fails during install

Simulate a failed install by adding an unknown module in Pipfile:
```
[packages]
foobarspam = "*"
```